### PR TITLE
[Refactor] use find for searchByEmployeeNum

### DIFF
--- a/EMS/EMS/SearchEngine.cpp
+++ b/EMS/EMS/SearchEngine.cpp
@@ -4,10 +4,9 @@ list<Employee*> SearchEngine::search(map<int, Employee>& db, int employeeNum) co
 {
 	list<Employee*> result;
 
-	for (auto& item : db) {
-		if (item.second.employeeNum != employeeNum) continue;
-		result.emplace_back(&item.second);
-	}
+	auto item = db.find(employeeNum);
+	if (item != db.end())
+		result.emplace_back(&(item->second));
 	return result;
 }
 

--- a/EMS/EMS/SearchEngine.h
+++ b/EMS/EMS/SearchEngine.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <map>
 #include <list>
 #include "Employee.h"
 


### PR DESCRIPTION
- map으로 데이터 형을 변환하며, 성능을 향상시키기 위해 employeeNum을 통한 탐색의 경우 find를 이용하도록 수정합니다.
 (employeeNum의 경우 고유번호이기 때문에 1개 혹은 0개 입니다!)