### PR TITLE
[Fix] print()에 string 인자전달

### DIFF
--- a/EMS/TestEMS/test_IOHandler.cpp
+++ b/EMS/TestEMS/test_IOHandler.cpp
@@ -71,13 +71,15 @@ TEST(IOHandlerTest, MOD) {
 	localFakeQueryResult.emplace_back(&data2);
 
 	EXPECT_CALL(mockDBMS, mod(_, _, _, _)).Times(1);
-	ON_CALL(mockDBMS, mod(_, _, _, _)).WillByDefault(Return(localFakeQueryResult));
+	ON_CALL(mockPrinter, print(localFakeQueryResult,string("MOD"))).WillByDefault(Return(localFakeQueryResult));
 	ioHandler->commandRequest("MOD,,,,name,JJIVL LFIS,name KKIVL KFIS");
 }
 
 TEST(IOHandlerTest, PRINT) {
-	EXPECT_CALL(mockDBMS, mod(_, _, _, _)).Times(1);
-	string cmd{"MOD"};
-	ON_CALL(mockPrinter, print(_, cmd));
+	list<Employee*> localFakeQueryResult;
+	localFakeQueryResult.emplace_back(&data2);
+
+	ON_CALL(mockDBMS, mod(_, _, _, _)).WillByDefault(Return(localFakeQueryResult));
+	EXPECT_CALL(mockPrinter, print(_, string("MOD"))).Times(1);
 	ioHandler->commandRequest("MOD,,,,name,JJIVL LFIS,name KKIVL KFIS");
 }

--- a/EMS/TestEMS/test_IOHandler.cpp
+++ b/EMS/TestEMS/test_IOHandler.cpp
@@ -77,6 +77,7 @@ TEST(IOHandlerTest, MOD) {
 
 TEST(IOHandlerTest, PRINT) {
 	EXPECT_CALL(mockDBMS, mod(_, _, _, _)).Times(1);
-	ON_CALL(mockPrinter, print(_, "MOD"));
+	string cmd{"MOD"};
+	ON_CALL(mockPrinter, print(_, cmd));
 	ioHandler->commandRequest("MOD,,,,name,JJIVL LFIS,name KKIVL KFIS");
 }


### PR DESCRIPTION
print()에 char*로 전달되어 문자가되던 문자열을 string으로 전달합니다.

Signed-off-by: kjh <cisc@kakao.com>