### PR TITLE
[Fix] -d 옵션 수정

### DIFF
--- a/EMS/EMS/IOHandler.cpp
+++ b/EMS/EMS/IOHandler.cpp
@@ -162,7 +162,7 @@ void IOHandler::parseOption2() {
 	else if (opt_string == "-y") {
 		opt2 = OPT2_TYPE::YEAR;
 	}
-	else if (cmd.substr(charIdx, 2) == "-D") {
+	else if (cmd.substr(charIdx, 2) == "-d") {
 		opt2 = OPT2_TYPE::DAY;
 	}
 	else {


### PR DESCRIPTION
-d 옵션이 대문자로 돼있어서 수정했습니다.

Signed-off-by: kjh <cisc@kakao.com>