### PR TITLE
[Fix] Parsing 수정 2

### DIFF
--- a/EMS/EMS/IOHandler.cpp
+++ b/EMS/EMS/IOHandler.cpp
@@ -209,13 +209,13 @@ static CL getCLEnum(const string& cl) {
 		return CL::CL1;
 	}
 	else if (cl == "CL2") {
-		return CL::CL1;
+		return CL::CL2;
 	}
 	else if (cl == "CL3") {
-		return CL::CL1;
+		return CL::CL3;
 	}
 	else if (cl == "CL4") {
-		return CL::CL1;
+		return CL::CL4;
 	}
 	else {
 		throw invalid_argument("Invalid CL");


### PR DESCRIPTION
[Fix] Parsing에서 CL이 잘못파싱됐습니다.

Signed-off-by: kjh <cisc@kakao.com>