### PR TITLE
[Fix] deliver pointer type variable

### DIFF
--- a/EMS/EMS/main.cpp
+++ b/EMS/EMS/main.cpp
@@ -13,11 +13,12 @@ int main(int argc, char* argv[]) {
 
 	if (inputFile.is_open()) {
 		string line;
-		Dbms dbms(new DataBase());
-		Printer printer(outputFile);
-		IOHandler io_handler((IDbms*)&dbms, (IPrinter*)&printer);
+		Dbms* dbms = new Dbms(new DataBase());
+		Printer* printer = new Printer(outputFile);
+		IOHandler io_handler((IDbms*)dbms, (IPrinter*)printer);
 
 		while (getline(inputFile, line)) {
+			cout << line << endl;
 			io_handler.commandRequest(line);
 		}
 	}

--- a/EMS/EMS/main.cpp
+++ b/EMS/EMS/main.cpp
@@ -18,7 +18,6 @@ int main(int argc, char* argv[]) {
 		IOHandler io_handler((IDbms*)dbms, (IPrinter*)printer);
 
 		while (getline(inputFile, line)) {
-			cout << line << endl;
 			io_handler.commandRequest(line);
 		}
 	}


### PR DESCRIPTION
IOHandler 의 소멸자 정상수행 위해 힙에 할당한 변수를 넘깁니다.