### PR TITLE
[Fix] IOHandler 옵션 파싱

### DIFF
--- a/EMS/EMS/IOHandler.cpp
+++ b/EMS/EMS/IOHandler.cpp
@@ -305,6 +305,8 @@ Column IOHandler::convertStringToColumn(string str) {
 		return Column::EMPLOYEE_NUM;
 	}
 	else if (str == "name") {
+		if (opt2 == OPT2_TYPE::FIRST) return Column::FIRST_NAME;
+		if (opt2 == OPT2_TYPE::LAST) return Column::LAST_NAME;
 		return Column::NAME;
 	}
 	else if (str == "cl") {


### PR DESCRIPTION
옵션 파싱 중 이름 파싱하는 부분이 누락되어 추가합니다.

Signed-off-by: kjh <cisc@kakao.com>